### PR TITLE
PayPal USA Standard : HTML form : Country ISO code

### DIFF
--- a/paypalusa/views/templates/hook/standard.tpl
+++ b/paypalusa/views/templates/hook/standard.tpl
@@ -25,6 +25,7 @@
 		<input type="hidden" name="amount" value="{$cart->getOrderTotal(true)|floatval}" />
 		<input type="hidden" name="first_name" value="{$paypal_usa_billing_address->firstname|escape:'htmlall':'UTF-8'}" />
 		<input type="hidden" name="last_name" value="{$paypal_usa_billing_address->lastname|escape:'htmlall':'UTF-8'}" />
+		<input type="hidden" name="country" value="{$paypal_usa_billing_address->country->iso_code|escape:'htmlall':'UTF-8'}" />
 		<input type="hidden" name="address1" value="{$paypal_usa_billing_address->address1|escape:'htmlall':'UTF-8'}" />
 		{if $paypal_usa_billing_address->address2}<input type="hidden" name="address2" value="{$paypal_usa_billing_address->address2|escape:'htmlall':'UTF-8'}" />{/if}
 		<input type="hidden" name="city" value="{$paypal_usa_billing_address->city|escape:'htmlall':'UTF-8'}" />


### PR DESCRIPTION
Since approximately January 2018, the country code seems required by PayPal
which will otherwise fallback to USA, causing this error message to Canadian customers :

```
There’s a problem with your shipping address.

Please return to the merchant and update your information, including your city, state, and ZIP code.

David Côté-Tremblay
2158 Yellow River St. undefined
Québec, QC G2N1T5
```

As you can see, there's some `undefined` keyword in the address.

This patch fixes this issue.